### PR TITLE
Add location arg to bucket backend setup

### DIFF
--- a/lib/terraspace_plugin_google/interfaces/backend.rb
+++ b/lib/terraspace_plugin_google/interfaces/backend.rb
@@ -14,14 +14,15 @@ module TerraspacePluginGoogle::Interfaces
       if exist?(bucket)
         logger.debug "Bucket already exist: #{bucket}"
       else
+        location = @info["location"]
         logger.info "Creating bucket: #{bucket}"
-        create_bucket(bucket)
+        create_bucket(bucket, location: location)
       end
     end
 
-    def create_bucket(bucket)
+    def create_bucket(bucket, location: nil)
       c = TerraspacePluginGoogle::Interfaces::Config.instance.config.gcs
-      storage.create_bucket(bucket) do |b|
+      storage.create_bucket(bucket, location: location) do |b|
         b.versioning = c.versioning
       end
     end


### PR DESCRIPTION
Passes location arg through to `create_bucket()` for backend setup
Solves #12 